### PR TITLE
5th release

### DIFF
--- a/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
+++ b/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.DataContract</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using DataContractSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
@@ -76,9 +76,9 @@ namespace Kampute.HttpClient.DataContract
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="content"/> or <paramref name="modelType"/> is <c>null</c>.</exception>
         public async Task<object?> DeserializeAsync(HttpContent content, Type modelType, CancellationToken cancellationToken = default)
         {
-            if (content == null)
+            if (content is null)
                 throw new ArgumentNullException(nameof(content));
-            if (modelType == null)
+            if (modelType is null)
                 throw new ArgumentNullException(nameof(modelType));
 
             var encoding = content.FindCharacterEncoding() ?? Encoding.UTF8;

--- a/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
@@ -49,7 +49,7 @@ namespace Kampute.HttpClient.DataContract
         /// </returns>
         public IReadOnlyCollection<string> GetSupportedMediaTypes(Type? modelType)
         {
-            return modelType?.GetCustomAttribute<DataContractAttribute>() is not null ? SupportedMediaTypes : Array.Empty<string>();
+            return modelType?.GetCustomAttribute<DataContractAttribute>() is not null ? SupportedMediaTypes : [];
         }
 
         /// <summary>

--- a/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
@@ -43,7 +43,7 @@ namespace Kampute.HttpClient.Json
         /// <returns>The read-only collection of media types that this deserializer supports if model type is not <c>null</c>; otherwise, an empty collection.</returns>
         public IReadOnlyCollection<string> GetSupportedMediaTypes(Type? modelType)
         {
-            return modelType is not null ? SupportedMediaTypes : Array.Empty<string>();
+            return modelType is not null ? SupportedMediaTypes : [];
         }
 
         /// <summary>

--- a/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
@@ -67,9 +67,9 @@ namespace Kampute.HttpClient.Json
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="content"/> or <paramref name="modelType"/> is <c>null</c>.</exception>
         public async Task<object?> DeserializeAsync(HttpContent content, Type modelType, CancellationToken cancellationToken = default)
         {
-            if (content == null)
+            if (content is null)
                 throw new ArgumentNullException(nameof(content));
-            if (modelType == null)
+            if (modelType is null)
                 throw new ArgumentNullException(nameof(modelType));
 
             var encoding = content.FindCharacterEncoding();

--- a/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
+++ b/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.Json</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using System.Text.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
@@ -68,9 +68,9 @@ namespace Kampute.HttpClient.NewtonsoftJson
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="content"/> or <paramref name="modelType"/> is <c>null</c>.</exception>
         public async Task<object?> DeserializeAsync(HttpContent content, Type modelType, CancellationToken cancellationToken = default)
         {
-            if (content == null)
+            if (content is null)
                 throw new ArgumentNullException(nameof(content));
-            if (modelType == null)
+            if (modelType is null)
                 throw new ArgumentNullException(nameof(modelType));
 
             var encoding = content.FindCharacterEncoding() ?? Encoding.UTF8;

--- a/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
@@ -44,7 +44,7 @@ namespace Kampute.HttpClient.NewtonsoftJson
         /// <returns>The read-only collection of media types that this deserializer supports if model type is not <c>null</c>; otherwise, an empty collection.</returns>
         public IReadOnlyCollection<string> GetSupportedMediaTypes(Type? modelType)
         {
-            return modelType is not null ? SupportedMediaTypes : Array.Empty<string>();
+            return modelType is not null ? SupportedMediaTypes : [];
         }
 
         /// <summary>

--- a/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
+++ b/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.NewtonsoftJson</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using Newtonsoft.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
+++ b/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.Xml</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using XmlSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
@@ -61,9 +61,9 @@ namespace Kampute.HttpClient.Xml
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="content"/> or <paramref name="modelType"/> is <c>null</c>.</exception>
         public async Task<object?> DeserializeAsync(HttpContent content, Type modelType, CancellationToken cancellationToken = default)
         {
-            if (content == null)
+            if (content is null)
                 throw new ArgumentNullException(nameof(content));
-            if (modelType == null)
+            if (modelType is null)
                 throw new ArgumentNullException(nameof(modelType));
 
             var encoding = content.FindCharacterEncoding() ?? Encoding.UTF8;

--- a/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
@@ -37,7 +37,7 @@ namespace Kampute.HttpClient.Xml
         /// <returns>The read-only collection of media types that this deserializer supports if model type is not <c>null</c>; otherwise, an empty collection.</returns>
         public IReadOnlyCollection<string> GetSupportedMediaTypes(Type? modelType)
         {
-            return modelType is not null ? SupportedMediaTypes : Array.Empty<string>();
+            return modelType is not null ? SupportedMediaTypes : [];
         }
 
         /// <summary>

--- a/src/Kampute.HttpClient/HttpContentException.cs
+++ b/src/Kampute.HttpClient/HttpContentException.cs
@@ -49,5 +49,13 @@ namespace Kampute.HttpClient
         /// The HTTP content associated with the exception, if any.
         /// </value>
         public HttpContent? Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expected type for deserialization when the exception occurred.
+        /// </summary>
+        /// <value>
+        /// The type expected to be deserialized from the HTTP content, if any.
+        /// </value>
+        public Type? ObjectType { get; set; }
     }
 }

--- a/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
+++ b/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
@@ -57,7 +57,7 @@ namespace Kampute.HttpClient
         /// <exception cref="ArgumentException">Thrown if <paramref name="errorHandler"/> is already present in the collection, as duplicates are not allowed.</exception>
         public void Add(IHttpErrorHandler errorHandler)
         {
-            if (errorHandler == null)
+            if (errorHandler is null)
                 throw new ArgumentNullException(nameof(errorHandler));
             if (_collection.Contains(errorHandler))
                 throw new ArgumentException("A duplicate error handler cannot be added to the collection.", nameof(errorHandler));

--- a/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
+++ b/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
@@ -8,32 +8,20 @@ namespace Kampute.HttpClient
     using Kampute.HttpClient.Interfaces;
     using System;
     using System.Collections;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
-    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// Represents a specialized collection of <see cref="IHttpErrorHandler"/> instances.
     /// </summary>
     /// <remarks>
-    /// <para>
     /// This collection enables the management of <see cref="IHttpErrorHandler"/> instances for handling HTTP errors, 
-    /// with capabilities such as adding, removing, and querying error handlers based on HTTP status codes. It leverages 
-    /// an internal caching mechanism to optimize the retrieval of error handlers for specific HTTP status codes. 
-    /// </para>
-    /// <para>
-    /// This cache is dynamically updated to reflect changes in the collection, ensuring that queries for error handlers 
-    /// are performed efficiently. The use of caching minimizes the need to repeatedly evaluate which handlers are applicable 
-    /// for a given status code, thereby enhancing performance, especially in scenarios where error handling is a frequent 
-    /// operation.
-    /// </para>
+    /// with capabilities such as adding, removing, and querying error handlers based on HTTP status codes. 
     /// </remarks>
     public sealed class HttpErrorHandlerCollection : ICollection<IHttpErrorHandler>
     {
         private readonly List<IHttpErrorHandler> _collection = [];
-        private readonly ConcurrentDictionary<HttpStatusCode, IReadOnlyCollection<IHttpErrorHandler>> _cache = new();
 
         /// <summary>
         /// Gets the number of <see cref="IHttpErrorHandler"/> instances contained in the collection.
@@ -55,11 +43,10 @@ namespace Kampute.HttpClient
         /// Retrieves all <see cref="IHttpErrorHandler"/> instances in the collection that support handling a specific HTTP status code.
         /// </summary>
         /// <param name="statusCode">The HTTP status code to query.</param>
-        /// <returns>A read-only collection of <see cref="IHttpErrorHandler"/> that can handle the specified status code.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IReadOnlyCollection<IHttpErrorHandler> For(HttpStatusCode statusCode)
+        /// <returns>An enumrable of <see cref="IHttpErrorHandler"/> that can handle the specified status code.</returns>
+        public IEnumerable<IHttpErrorHandler> GetHandlersFor(HttpStatusCode statusCode)
         {
-            return _cache.GetOrAdd(statusCode, _ => _collection.Where(errorHandler => errorHandler.CanHandle(statusCode)).ToArray());
+            return _collection.Where(errorHandler => errorHandler.CanHandle(statusCode));
         }
 
         /// <summary>
@@ -76,7 +63,6 @@ namespace Kampute.HttpClient
                 throw new ArgumentException("A duplicate error handler cannot be added to the collection.", nameof(errorHandler));
 
             _collection.Add(errorHandler);
-            UpdateCacheForErrorHandler(errorHandler);
         }
 
         /// <summary>
@@ -86,12 +72,7 @@ namespace Kampute.HttpClient
         /// <returns><c>true</c> if <paramref name="errorHandler"/> was successfully removed from the collection; otherwise, <c>false</c>.</returns>
         public bool Remove(IHttpErrorHandler errorHandler)
         {
-            if (_collection.Remove(errorHandler))
-            {
-                UpdateCacheForErrorHandler(errorHandler);
-                return true;
-            }
-            return false;
+            return _collection.Remove(errorHandler);
         }
 
         /// <summary>
@@ -110,7 +91,6 @@ namespace Kampute.HttpClient
         public void Clear()
         {
             _collection.Clear();
-            _cache.Clear();
         }
 
         /// <summary>
@@ -139,27 +119,6 @@ namespace Kampute.HttpClient
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
-        }
-
-        /// <summary>
-        /// Updates the cache entries related to a specific <see cref="IHttpErrorHandler"/>.
-        /// </summary>
-        /// <param name="errorHandler">The <see cref="IHttpErrorHandler"/> for which the cache should be updated.</param>
-        /// <remarks>
-        /// This method removes the cache entries for HTTP status codes that the given <paramref name="errorHandler"/> can handle.
-        /// This ensures that the cache stays up-to-date when error handlers are added or removed from the collection.
-        /// </remarks>
-        private void UpdateCacheForErrorHandler(IHttpErrorHandler errorHandler)
-        {
-            if (_cache.Count == 0)
-                return;
-
-            var invalidatedCacheKeys = _cache.Keys.Where(errorHandler.CanHandle).ToList();
-            if (invalidatedCacheKeys.Count == 0)
-                return;
-
-            foreach (var statusCode in invalidatedCacheKeys)
-                _cache.TryRemove(statusCode, out _);
         }
     }
 }

--- a/src/Kampute.HttpClient/HttpRestClient.cs
+++ b/src/Kampute.HttpClient/HttpRestClient.cs
@@ -52,31 +52,28 @@ namespace Kampute.HttpClient
     public class HttpRestClient : IDisposable, ICloneable
     {
         private static readonly MediaTypeWithQualityHeaderValue AnyMediaType = new("*/*", 0.1);
+        private static readonly SharedDisposable<HttpClient> SharedHttpClient = new(CreateDefaultHttpClient);
 
-        private static readonly SharedDisposable<HttpClient> _sharedHttpClient = new(() =>
+        private static HttpClient CreateDefaultHttpClient()
         {
             var messageHandler = new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
             return new HttpClient(messageHandler, disposeHandler: true);
-        });
-
-        private readonly HttpClient _httpClient;
-        private readonly bool _disposeClient;
-
-        private Uri? _baseAddress = null;
-        private Type? _responseErrorType = null;
-        private IRetrySchedulerFactory _backoffStrategy = BackoffStrategies.None;
-        private readonly HttpErrorHandlerCollection _errorHandlers = [];
-        private readonly HttpContentDeserializerCollection _deserializers = [];
-        private readonly HttpRequestHeaders _defaultRequestHeaders = CreateRequestHeaders();
+        }
 
         private static HttpRequestHeaders CreateRequestHeaders()
         {
             using var request = new HttpRequestMessage();
             return request.Headers;
         }
+
+        private readonly HttpClient _httpClient;
+        private readonly bool _disposeClient;
+
+        private Uri? _baseAddress = null;
+        private IRetrySchedulerFactory _backoffStrategy = BackoffStrategies.None;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpRestClient"/> class with a default <see cref="HttpClient"/>.
@@ -94,7 +91,7 @@ namespace Kampute.HttpClient
         /// </para>
         /// </remarks>
         public HttpRestClient()
-            : this(_sharedHttpClient.Acquire(), false)
+            : this(SharedHttpClient.Acquire(), false)
         {
         }
 
@@ -204,11 +201,7 @@ namespace Kampute.HttpClient
         /// returned from the server.
         /// </para>
         /// </remarks>
-        public Type? ResponseErrorType
-        {
-            get => _responseErrorType;
-            set => _responseErrorType = value;
-        }
+        public Type? ResponseErrorType { get; set; }
 
         /// <summary>
         /// Gets or sets the backoff strategy for handling transient connection failures during HTTP requests.
@@ -237,7 +230,7 @@ namespace Kampute.HttpClient
         /// This property provides access to a collection of <see cref="IHttpErrorHandler"/> instances that are used to handle 
         /// HTTP error responses. The handlers in this collection are tried in order to handle errors.
         /// </remarks>
-        public HttpErrorHandlerCollection ErrorHandlers => _errorHandlers;
+        public HttpErrorHandlerCollection ErrorHandlers { get; } = [];
 
         /// <summary>
         /// Gets the mutable collection of HTTP content deserializers used for deserializing response content.
@@ -250,7 +243,7 @@ namespace Kampute.HttpClient
         /// deserialize the content of HTTP responses. The deserializers in this list are tried in order to deserialize the response 
         /// content into .NET objects.
         /// </remarks>
-        public HttpContentDeserializerCollection ResponseDeserializers => _deserializers;
+        public HttpContentDeserializerCollection ResponseDeserializers { get; } = [];
 
         /// <summary>
         ///  Gets the headers which should be sent with each request.
@@ -258,7 +251,7 @@ namespace Kampute.HttpClient
         /// <value>
         /// The headers which should be sent with each request.
         /// </value>
-        public HttpRequestHeaders DefaultRequestHeaders => _defaultRequestHeaders;
+        public HttpRequestHeaders DefaultRequestHeaders { get; } = CreateRequestHeaders();
 
         /// <summary>
         /// Creates a copy of the current <see cref="HttpRestClient"/> instance.
@@ -271,19 +264,19 @@ namespace Kampute.HttpClient
         /// </remarks>
         public object Clone()
         {
-            var clone = new HttpRestClient(_sharedHttpClient.Is(_httpClient) ? _sharedHttpClient.Acquire() : _httpClient, false)
+            var clone = new HttpRestClient(SharedHttpClient.Is(_httpClient) ? SharedHttpClient.Acquire() : _httpClient, false)
             {
                 _baseAddress = _baseAddress,
-                _responseErrorType = _responseErrorType,
                 _backoffStrategy = _backoffStrategy,
+                ResponseErrorType = ResponseErrorType,
             };
 
-            foreach (var errorHandler in _errorHandlers)
-                clone._errorHandlers.Add(errorHandler);
-            foreach (var deserializer in _deserializers)
-                clone._deserializers.Add(deserializer);
-            foreach (var header in _defaultRequestHeaders)
-                clone._defaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
+            foreach (var errorHandler in ErrorHandlers)
+                clone.ErrorHandlers.Add(errorHandler);
+            foreach (var deserializer in ResponseDeserializers)
+                clone.ResponseDeserializers.Add(deserializer);
+            foreach (var header in DefaultRequestHeaders)
+                clone.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
 
             return clone;
         }
@@ -511,7 +504,7 @@ namespace Kampute.HttpClient
 
             var context = new HttpResponseErrorContext(this, request, response, error);
 
-            foreach (var errorHandler in _errorHandlers.GetHandlersFor(response.StatusCode))
+            foreach (var errorHandler in ErrorHandlers.GetHandlersFor(response.StatusCode))
             {
                 var decision = await errorHandler.DecideOnRetryAsync(context, cancellationToken).ConfigureAwait(false);
                 if (decision.RequestToRetry is not null)
@@ -586,11 +579,11 @@ namespace Kampute.HttpClient
                 throw new ArgumentNullException(nameof(response));
 
             var responseObject = default(object);
-            if (_responseErrorType is not null)
+            if (ResponseErrorType is not null)
             {
                 try
                 {
-                    responseObject = await DeserializeContentAsync(response.Content, _responseErrorType, cancellationToken).ConfigureAwait(false);
+                    responseObject = await DeserializeContentAsync(response.Content, ResponseErrorType, cancellationToken).ConfigureAwait(false);
                 }
                 catch
                 {
@@ -630,30 +623,32 @@ namespace Kampute.HttpClient
                 return null;
 
             if (content.Headers.ContentType is null)
+                throw Error("The content type of the response is unknown.");
+
+            var deserializer = ResponseDeserializers.GetDeserializerFor(content.Headers.ContentType.MediaType, objectType)
+                ?? throw Error($"Unable to deserialize content of type '{content.Headers.ContentType.MediaType}' into '{objectType.Name}' due to the absence of a matching deserializer.");
+
+            try
             {
-                throw new HttpContentException("The content type of the response could not be determined.")
+                return await deserializer.DeserializeAsync(content, objectType, cancellationToken).ConfigureAwait(false);
+            }
+            catch (TaskCanceledException)
+            {
+                throw;
+            }
+            catch (Exception error)
+            {
+                throw Error($"Failed to deserialize the content of type '{content.Headers.ContentType.MediaType}' into '{objectType.Name}'. Check the inner exception for details.", error);
+            }
+
+            HttpContentException Error(string message, Exception? innerException = null)
+            {
+                return new HttpContentException(message, innerException)
                 {
-                    Content = content
+                    Content = content,
+                    ObjectType = objectType,
                 };
             }
-
-            var deserializerError = default(Exception);
-            foreach (var deserializer in _deserializers.For(content.Headers.ContentType.MediaType, objectType))
-            {
-                try
-                {
-                    return await deserializer.DeserializeAsync(content, objectType, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception error)
-                {
-                    deserializerError = error;
-                }
-            }
-
-            throw new HttpContentException($"The content type '{content.Headers.ContentType.MediaType}' could not be converted into type '{objectType.Name}'.", deserializerError)
-            {
-                Content = content
-            };
         }
 
         /// <summary>
@@ -702,10 +697,10 @@ namespace Kampute.HttpClient
             var requestUri = _baseAddress is null ? new Uri(uri) : new Uri(_baseAddress, uri);
             var request = new HttpRequestMessage(method, requestUri);
 
-            foreach (var header in _defaultRequestHeaders)
+            foreach (var header in DefaultRequestHeaders)
                 request.Headers.TryAddWithoutValidation(header.Key, header.Value);
 
-            foreach (var mediaType in _deserializers.GetSupportedMediaTypes(responseObjectType, _responseErrorType))
+            foreach (var mediaType in ResponseDeserializers.GetAcceptableMediaTypes(responseObjectType, ResponseErrorType))
                 request.Headers.Accept.Add(mediaType);
 
             if (responseObjectType is null)
@@ -732,8 +727,8 @@ namespace Kampute.HttpClient
                 }
                 finally
                 {
-                    if (_sharedHttpClient.Is(_httpClient))
-                        _sharedHttpClient.Release(_httpClient);
+                    if (SharedHttpClient.Is(_httpClient))
+                        SharedHttpClient.Release(_httpClient);
                     else if (_disposeClient)
                         _httpClient.Dispose();
                 }

--- a/src/Kampute.HttpClient/HttpRestClient.cs
+++ b/src/Kampute.HttpClient/HttpRestClient.cs
@@ -511,7 +511,7 @@ namespace Kampute.HttpClient
 
             var context = new HttpResponseErrorContext(this, request, response, error);
 
-            foreach (var errorHandler in _errorHandlers.For(response.StatusCode))
+            foreach (var errorHandler in _errorHandlers.GetHandlersFor(response.StatusCode))
             {
                 var decision = await errorHandler.DecideOnRetryAsync(context, cancellationToken).ConfigureAwait(false);
                 if (decision.RequestToRetry is not null)

--- a/src/Kampute.HttpClient/Kampute.HttpClient.csproj
+++ b/src/Kampute.HttpClient/Kampute.HttpClient.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <Title>Kampute.HttpClient</Title>
-    <Description>Kampute.HttpClient is a .NET library for streamlined RESTful API communication. It offers a highly customizable HttpRestClient class for efficient HTTP interactions, supporting advanced features like flexible serialization/deserialization, robust error handling, backoff strategies, and detailed request-response processing. Designed for both simplicity and extensibility, it's ideal for developers seeking a versatile client for API integration in diverse .NET applications.</Description>
+    <Description>Kampute.HttpClient is a versatile and lightweight .NET library that simplifies RESTful API communication. Its core HttpRestClient class provides a streamlined approach to HTTP interactions, offering advanced features such as flexible serialization/deserialization, robust error handling, configurable backoff strategies, and detailed request-response processing. Striking a balance between simplicity and extensibility, Kampute.HttpClient empowers developers with a powerful yet easy-to-use client for seamless API integration across a wide range of .NET applications.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/tests/Kampute.HttpClient.Test/HttpContentDeserializerCollectionTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpContentDeserializerCollectionTests.cs
@@ -5,28 +5,27 @@
     using Moq;
     using NUnit.Framework;
     using System;
-    using System.Linq;
     using System.Net.Http.Headers;
 
     [TestFixture]
     public class HttpContentDeserializerCollectionTests
     {
         [Test]
-        public void For_MediaTypeAndModelType_ReturnsCorrectDeserializers()
+        public void GetDeserializerFor_MediaTypeAndModelType_ReturnsCorrectDeserializers()
         {
             var collection = new HttpContentDeserializerCollection
             {
                 new TestContentDeserializer()
             };
 
-            var result = collection.For(Constants.TestMediaType, typeof(string));
+            var result = collection.GetDeserializerFor(Constants.TestMediaType, typeof(string));
 
-            Assert.That(result, Has.Exactly(1).Items);
-            Assert.That(result.First(), Is.TypeOf<TestContentDeserializer>());
+            Assert.That(result, Is.Not.Null);
+            Assert.That(result, Is.TypeOf<TestContentDeserializer>());
         }
 
         [Test]
-        public void GetSupportedMediaTypes_ModelType_ReturnsCorrectMediaTypes()
+        public void GetAcceptableMediaTypes_ModelType_ReturnsCorrectMediaTypeHeaderValues()
         {
             var modelType = typeof(string);
             var expectedMediaTypes = new[]
@@ -39,13 +38,13 @@
                 new TestContentDeserializer()
             };
 
-            var result = collection.GetSupportedMediaTypes(modelType);
+            var result = collection.GetAcceptableMediaTypes(modelType);
 
             Assert.That(result, Is.EqualTo(expectedMediaTypes));
         }
 
         [Test]
-        public void GetSupportedMediaTypes_ModelTypeAndErrorType_ReturnsCorrectMediaTypes()
+        public void GetAcceptableMediaTypes_ModelTypeAndErrorType_ReturnsCorrectMediaTypeHeaderValus()
         {
             var modelType = typeof(string);
             var errorType = typeof(object);
@@ -65,7 +64,7 @@
                 new TestContentDeserializer(),
             };
 
-            var result = collection.GetSupportedMediaTypes(modelType, errorType);
+            var result = collection.GetAcceptableMediaTypes(modelType, errorType);
 
             Assert.That(result, Is.EquivalentTo(expectedMediaTypes));
         }

--- a/tests/Kampute.HttpClient.Test/HttpErrorHandlerCollectionTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpErrorHandlerCollectionTests.cs
@@ -10,7 +10,7 @@
     public class HttpErrorHandlerCollectionTests
     {
         [Test]
-        public void For_StatusCode_ReturnsCorrectErrorHandlers()
+        public void GetHandlersFor_StatusCode_ReturnsCorrectErrorHandlers()
         {
             var statusCode = HttpStatusCode.Unauthorized;
             var collection = new HttpErrorHandlerCollection();
@@ -21,7 +21,7 @@
                 collection.Add(errorHandlerMock.Object);
             }
 
-            var result = collection.For(statusCode);
+            var result = collection.GetHandlersFor(statusCode);
 
             Assert.That(result, Has.Exactly(3).Items);
         }
@@ -102,68 +102,6 @@
             collection.Clear();
 
             Assert.That(collection, Is.Empty);
-        }
-
-        [Test]
-        public void Add_UpdatesCacheCorrectly()
-        {
-            var statusCode = HttpStatusCode.Unauthorized;
-            var collection = new HttpErrorHandlerCollection();
-            var errorHandlerMock = new Mock<IHttpErrorHandler>();
-            errorHandlerMock.Setup(errorHandler => errorHandler.CanHandle(statusCode)).Returns(true);
-
-            collection.Add(errorHandlerMock.Object);
-
-            var handlers = collection.For(statusCode);
-            Assert.That(handlers, Has.Count.EqualTo(1));
-            Assert.That(handlers, Contains.Item(errorHandlerMock.Object));
-        }
-
-        [Test]
-        public void Remove_UpdatesCacheCorrectly()
-        {
-            var statusCode = HttpStatusCode.Unauthorized;
-            var collection = new HttpErrorHandlerCollection();
-            var errorHandlerMock = new Mock<IHttpErrorHandler>();
-            errorHandlerMock.Setup(errorHandler => errorHandler.CanHandle(statusCode)).Returns(true);
-            collection.Add(errorHandlerMock.Object);
-
-            collection.Remove(errorHandlerMock.Object);
-
-            var handlers = collection.For(statusCode);
-            Assert.That(handlers, Is.Empty);
-        }
-
-        [Test]
-        public void Clear_UpdatesCacheCorrectly()
-        {
-            var statusCode = HttpStatusCode.Unauthorized;
-            var collection = new HttpErrorHandlerCollection();
-            var errorHandlerMock = new Mock<IHttpErrorHandler>();
-            errorHandlerMock.Setup(errorHandler => errorHandler.CanHandle(statusCode)).Returns(true);
-
-            collection.Clear();
-
-            var handlers = collection.For(statusCode);
-            Assert.That(handlers, Is.Empty);
-        }
-
-        [Test]
-        public void CacheConsistencyAfterMultipleOperations()
-        {
-            var statusCode = HttpStatusCode.Unauthorized;
-            var collection = new HttpErrorHandlerCollection();
-            var errorHandlerMock1 = new Mock<IHttpErrorHandler>();
-            errorHandlerMock1.Setup(errorHandler => errorHandler.CanHandle(statusCode)).Returns(true);
-            var errorHandlerMock2 = new Mock<IHttpErrorHandler>();
-            errorHandlerMock2.Setup(errorHandler => errorHandler.CanHandle(statusCode)).Returns(false);
-
-            collection.Add(errorHandlerMock1.Object);
-            collection.Add(errorHandlerMock2.Object);
-            collection.Remove(errorHandlerMock1.Object);
-
-            var handlers = collection.For(statusCode);
-            Assert.That(handlers, Is.Empty);
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/TestHelpers/TestContentDeserializer.cs
+++ b/tests/Kampute.HttpClient.Test/TestHelpers/TestContentDeserializer.cs
@@ -10,14 +10,11 @@
 
     internal class TestContentDeserializer : IHttpContentDeserializer
     {
-        public IReadOnlyCollection<string> SupportedMediaTypes { get; } = new[]
-        {
-            Constants.TestMediaType
-        };
+        public IReadOnlyCollection<string> SupportedMediaTypes { get; } = [Constants.TestMediaType];
 
         public IReadOnlyCollection<string> GetSupportedMediaTypes(Type? modelType)
         {
-            return modelType is not null && CanParse(modelType) ? SupportedMediaTypes : Array.Empty<string>();
+            return modelType is not null && CanParse(modelType) ? SupportedMediaTypes : [];
         }
 
         public bool CanDeserialize(string mediaType, Type? modelType)


### PR DESCRIPTION
- Used better error messages for content deserialization issues.
- Added the `ObjectType` property to the `HttpContentException` class to provide more information regarding the error.
- Removed over-engineered caching mechanism from the `HttpContentDeserializerCollection` and `HttpErrorHandlerCollection` classes.
- Applied some code style enhancements