### PR TITLE
V2.4.0

### DIFF
--- a/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
+++ b/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.DataContract</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using DataContractSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
+++ b/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.Json</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using System.Text.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.6" />
+    <PackageReference Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
+++ b/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.NewtonsoftJson</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using Newtonsoft.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
+++ b/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.Xml</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using XmlSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient/Interfaces/IHttpErrorResponse.cs
+++ b/src/Kampute.HttpClient/Interfaces/IHttpErrorResponse.cs
@@ -1,12 +1,12 @@
-﻿using System.Net;
-
-// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2024 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.
 
 namespace Kampute.HttpClient.Interfaces
 {
+    using System.Net;
+
     /// <summary>
     /// Defines an interface for handling HTTP error responses and converting them into a <see cref="HttpResponseException"/>.
     /// </summary>

--- a/src/Kampute.HttpClient/Kampute.HttpClient.csproj
+++ b/src/Kampute.HttpClient/Kampute.HttpClient.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient</Title>
     <Description>Kampute.HttpClient is a versatile and lightweight .NET library that simplifies RESTful API communication. Its core HttpRestClient class provides a streamlined approach to HTTP interactions, offering advanced features such as flexible serialization/deserialization, robust error handling, configurable backoff strategies, and detailed request-response processing. Striking a balance between simplicity and extensibility, Kampute.HttpClient empowers developers with a powerful yet easy-to-use client for seamless API integration across a wide range of .NET applications.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.3.2</Version>
+    <Version>2.4.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2024 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient/MediaTypeHeaderValueStore.cs
+++ b/src/Kampute.HttpClient/MediaTypeHeaderValueStore.cs
@@ -1,7 +1,6 @@
-﻿using Kampute.HttpClient.Utilities;
-
-namespace Kampute.HttpClient
+﻿namespace Kampute.HttpClient
 {
+    using Kampute.HttpClient.Utilities;
     using System;
     using System.Net.Http.Headers;
 

--- a/tests/Kampute.HttpClient.DataContract.Test/Kampute.HttpClient.DataContract.Test.csproj
+++ b/tests/Kampute.HttpClient.DataContract.Test/Kampute.HttpClient.DataContract.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/tests/Kampute.HttpClient.Json.Test/Kampute.HttpClient.Json.Test.csproj
+++ b/tests/Kampute.HttpClient.Json.Test/Kampute.HttpClient.Json.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/tests/Kampute.HttpClient.NewtonsoftJson.Test/Kampute.HttpClient.NewtonsoftJson.Test.csproj
+++ b/tests/Kampute.HttpClient.NewtonsoftJson.Test/Kampute.HttpClient.NewtonsoftJson.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/tests/Kampute.HttpClient.Test/Kampute.HttpClient.Test.csproj
+++ b/tests/Kampute.HttpClient.Test/Kampute.HttpClient.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/tests/Kampute.HttpClient.Test/Utilities/SharedDisposableTests.cs
+++ b/tests/Kampute.HttpClient.Test/Utilities/SharedDisposableTests.cs
@@ -78,12 +78,12 @@
         [Test]
         public void SharedDisposable_MaintainsCorrectReferenceCount_OnConcurrentAcquireAndDispose()
         {
-            int numberOfThreads = 100;
+            var numberOfThreads = 100;
             var threads = new Thread[numberOfThreads];
-            int createdCount = 0;
+            var createdCount = 0;
 
             var sharedDisposable = new SharedDisposable<TestDisposable>(() => new TestDisposable());
-            for (int i = 0; i < numberOfThreads; i++)
+            for (var i = 0; i < numberOfThreads; i++)
             {
                 threads[i] = new Thread(() =>
                 {
@@ -93,10 +93,10 @@
                 });
             }
 
-            foreach (Thread thread in threads)
+            foreach (var thread in threads)
                 thread.Start();
 
-            foreach (Thread thread in threads)
+            foreach (var thread in threads)
                 thread.Join();
 
             Assert.Multiple(() =>

--- a/tests/Kampute.HttpClient.Xml.Test/Kampute.HttpClient.Xml.Test.csproj
+++ b/tests/Kampute.HttpClient.Xml.Test/Kampute.HttpClient.Xml.Test.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />


### PR DESCRIPTION
This pull request updates the Kampute.HttpClient core and extension packages to version 2.4.0, upgrades key dependencies, and makes minor code style improvements. The changes focus on keeping dependencies current and maintaining code consistency across the solution.

**Version and Dependency Updates:**

* Bumped the version of all main project packages (`Kampute.HttpClient`, `Kampute.HttpClient.DataContract`, `Kampute.HttpClient.Json`, `Kampute.HttpClient.NewtonsoftJson`, and `Kampute.HttpClient.Xml`) from 2.3.2 to 2.4.0. [[1]](diffhunk://#diff-1ee0b2a7278595f8a6039e98fc9e4a22c974001ccc0c81ad795370c06a684aeaL8-R8) [[2]](diffhunk://#diff-98cfbfd90ea7ec1df29d0b19aad62e2206286c196addbc12125bb7cda1df2643L8-R8) [[3]](diffhunk://#diff-2ee4ab9e1f5c14c19d8e5afe317c9396379fb3209784c6cbe0ad39d763bfd6c2L8-R8) [[4]](diffhunk://#diff-6215240a5f2a08d30bc9d031b739abdb968869584b36553bce92886f72cd64c0L8-R8) [[5]](diffhunk://#diff-8127010d589c2b8b02d06c68fc3e48bfc5222570f6750c29af4b3ab298e4620fL8-R8)
* Upgraded `System.Text.Json` dependency from 8.0.6 to 10.0.0 in `Kampute.HttpClient.Json`.
* Upgraded `Newtonsoft.Json` dependency from 13.0.3 to 13.0.4 in `Kampute.HttpClient.NewtonsoftJson`.
* Updated `Microsoft.NET.Test.Sdk` from 18.0.0 to 18.0.1 in all test projects for improved test infrastructure. [[1]](diffhunk://#diff-1744a33ede71c4167ce0ba705c5b2e7f07f873c55d4c7063e6f5d7a4f9bb75c2L13-R13) [[2]](diffhunk://#diff-e0e48c5efbda14c0a851d3320580411c849b162b07af5dfa552dbde60ab70502L13-R13) [[3]](diffhunk://#diff-c0703ad13498be53a0353f3173be8fe70a9f67f2b65c902905a4946d1bedd33fL13-R13) [[4]](diffhunk://#diff-919fdc3138e6c58deffab1ffbc30bc974d2c899a53df7a87d9dde790267de857L13-R13) [[5]](diffhunk://#diff-507136bf66195dcb1a01c2848eec4ae5699ea259f6dd654d7b6eff557c2940faL13-R13)

**Code Style and Consistency Improvements:**

* Standardized the use of `var` in place of explicit types in `SharedDisposableTests` for consistency. [[1]](diffhunk://#diff-af0178887ef4fbb15095d90f697cadcb0ec9dcdef8c9145ea0198a173e610e1eL81-R86) [[2]](diffhunk://#diff-af0178887ef4fbb15095d90f697cadcb0ec9dcdef8c9145ea0198a173e610e1eL96-R99)
* Moved `using` statements inside namespaces in `IHttpErrorResponse.cs` and `MediaTypeHeaderValueStore.cs` to match current C# conventions. [[1]](diffhunk://#diff-6ea6e10671a1e7523d9db8f5f73bc7f61f32c13e9a5bcc28f70c7aee58a98e72L1-R9) [[2]](diffhunk://#diff-db0c6e03d35e3e8243c4f2cac96a068b178f9b198e0e92cc379429b6a22bb58eL1-R3)