### PR TITLE
V2.5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Setup .NET 8.0
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - name: Install Kampose
       run: dotnet tool install --global kampose
@@ -43,3 +43,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./.site
+        keep_files: false

--- a/src/Kampute.HttpClient.DataContract/HttpRestClientXmlExtensions.cs
+++ b/src/Kampute.HttpClient.DataContract/HttpRestClientXmlExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.DataContract package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
+++ b/src/Kampute.HttpClient.DataContract/Kampute.HttpClient.DataContract.csproj
@@ -5,9 +5,9 @@
     <Title>Kampute.HttpClient.DataContract</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using DataContractSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Company>Kampute</Company>
-    <Copyright>Copyright (c) 2024 Kampute</Copyright>
+    <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Kampute.HttpClient.DataContract/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient.DataContract/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.DataContract/XmlContent.cs
+++ b/src/Kampute.HttpClient.DataContract/XmlContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.DataContract package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.DataContract/XmlContentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.DataContract package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Json/HttpRestClientJsonExtensions.cs
+++ b/src/Kampute.HttpClient.Json/HttpRestClientJsonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Json package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Json/JsonContent.cs
+++ b/src/Kampute.HttpClient.Json/JsonContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Json package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Json/JsonContentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Json package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
+++ b/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
+++ b/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
@@ -5,7 +5,7 @@
     <Title>Kampute.HttpClient.Json</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using System.Text.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Company>Kampute</Company>
     <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>

--- a/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
+++ b/src/Kampute.HttpClient.Json/Kampute.HttpClient.Json.csproj
@@ -7,7 +7,7 @@
     <Authors>Kambiz Khojasteh</Authors>
     <Version>2.4.0</Version>
     <Company>Kampute</Company>
-    <Copyright>Copyright (c) 2024 Kampute</Copyright>
+    <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Kampute.HttpClient.Json/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient.Json/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.NewtonsoftJson/HttpRestClientJsonExtensions.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/HttpRestClientJsonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.NewtonsoftJson package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.NewtonsoftJson/JsonContent.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/JsonContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.NewtonsoftJson package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/JsonContentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.NewtonsoftJson package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
+++ b/src/Kampute.HttpClient.NewtonsoftJson/Kampute.HttpClient.NewtonsoftJson.csproj
@@ -5,9 +5,9 @@
     <Title>Kampute.HttpClient.NewtonsoftJson</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/json content types, using Newtonsoft.Json library for serialization and deserialization of JSON responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Company>Kampute</Company>
-    <Copyright>Copyright (c) 2024 Kampute</Copyright>
+    <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kampute.HttpClient.NewtonsoftJson/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient.NewtonsoftJson/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Xml/HttpRestClientXmlExtensions.cs
+++ b/src/Kampute.HttpClient.Xml/HttpRestClientXmlExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Xml package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
+++ b/src/Kampute.HttpClient.Xml/Kampute.HttpClient.Xml.csproj
@@ -5,9 +5,9 @@
     <Title>Kampute.HttpClient.Xml</Title>
     <Description>This package is an extension package for Kampute.HttpClient, enhancing it to manage application/xml content types, using XmlSerializer for serialization and deserialization of XML responses and payloads.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Company>Kampute</Company>
-    <Copyright>Copyright (c) 2024 Kampute</Copyright>
+    <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Kampute.HttpClient.Xml/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient.Xml/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Xml/XmlContent.cs
+++ b/src/Kampute.HttpClient.Xml/XmlContent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Xml package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
+++ b/src/Kampute.HttpClient.Xml/XmlContentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient.Xml package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/AuthSchemes.cs
+++ b/src/Kampute.HttpClient/AuthSchemes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/BackoffStrategies.cs
+++ b/src/Kampute.HttpClient/BackoffStrategies.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Content/Abstracts/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Content/Abstracts/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Content/Compression/Abstracts/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Content/Compression/Abstracts/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Content/Compression/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Content/Compression/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Content/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Content/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/Abstracts/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/Abstracts/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/Abstracts/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/Abstracts/NamespaceDoc.cs
@@ -1,0 +1,13 @@
+// Copyright (C) 2024 Kampute
+//
+// This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
+// See the LICENSE file in the project root for the full license text.
+
+namespace Kampute.HttpClient.ErrorHandlers.Abstracts
+{
+    /// <summary>
+    /// This namespace contains abstract classes for handling transient HTTP error responses by implementing
+    /// backoff and retry strategies.
+    /// </summary>
+    internal static class NamespaceDoc { }
+}

--- a/src/Kampute.HttpClient/ErrorHandlers/Abstracts/RetryableHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/Abstracts/RetryableHttpErrorHandler.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (C) 2024 Kampute
+//
+// This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
+// See the LICENSE file in the project root for the full license text.
+
+namespace Kampute.HttpClient.ErrorHandlers.Abstracts
+{
+    using Kampute.HttpClient.Interfaces;
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provides the base functionality for handling HTTP responses with transient error status codes by attempting to back off and
+    /// retry the request according to a specified or default backoff strategy.
+    /// </summary>
+    /// <remarks>
+    /// This handler class is designed to be extended for specific transient error status codes. It offers a mechanism to respond to
+    /// transient HTTP errors by retrying the request after a delay. The delay duration and retry logic can be customized through the
+    /// <see cref="OnBackoffStrategy"/> delegate.
+    /// </remarks>
+    /// <seealso cref="HttpRestClient.ErrorHandlers"/>
+    /// <seealso cref="HttpRestClient.BackoffStrategy"/>
+    public abstract class RetryableHttpErrorHandler : IHttpErrorHandler
+    {
+        /// <summary>
+        /// A delegate that allows customization of the backoff strategy when responses with transient error status codes are received.
+        /// </summary>
+        /// <value>
+        /// A function that takes an <see cref="HttpResponseErrorContext"/> and an optional <see cref="DateTimeOffset"/> representing
+        /// the suggested retry time, and returns an <see cref="IHttpBackoffProvider"/> to be used for the retry operation.
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// If this delegate is set and returns an <see cref="IHttpBackoffProvider"/>, the returned strategy is used for the retry operation.
+        /// If it is not set, or returns <see langword="null"/>, a default behavior is applied.
+        /// </para>
+        /// <para>
+        /// The delegate receives the following parameters:
+        /// <list type="bullet">
+        ///   <item>
+        ///     <term>context</term>
+        ///     <description>
+        ///     Provides context about the HTTP response that indicates a transient error. It is encapsulated within an <see cref="HttpResponseErrorContext"/>
+        ///     instance, allowing for an informed decision on the retry strategy.
+        ///     </description>
+        ///   </item>
+        ///   <item>
+        ///     <term>retryTime</term>
+        ///     <description>
+        ///       Advises on the next retry attempt timing as a <see cref="DateTimeOffset"/> value if the response suggests one. If the response
+        ///       does not include a suggested retry time, the value will be <see langword="null"/>.
+        ///     </description>
+        ///   </item>
+        /// </list>
+        /// </para>
+        /// </remarks>
+        public Func<HttpResponseErrorContext, DateTimeOffset?, IHttpBackoffProvider?>? OnBackoffStrategy { get; set; }
+
+        /// <summary>
+        /// Determines whether this handler can process the specified HTTP status code.
+        /// </summary>
+        /// <param name="statusCode">The HTTP status code to evaluate.</param>
+        /// <returns><see langword="true"/> if the handler can process the status code; otherwise, <see langword="false"/>.</returns>
+        public abstract bool CanHandle(HttpStatusCode statusCode);
+
+        /// <summary>
+        /// Extracts the suggested retry time from the HTTP response's header, if present.
+        /// </summary>
+        /// <param name="ctx">The context containing information about the HTTP response.</param>
+        /// <returns>The suggested <see cref="DateTimeOffset"/> to retry the request, or <see langword="null"/> if the header is not present.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="ctx"/> is <see langword="null"/>.</exception>
+        protected virtual DateTimeOffset? GetSuggestedRetryTime(HttpResponseErrorContext ctx)
+        {
+            if (ctx is null)
+                throw new ArgumentNullException(nameof(ctx));
+
+            ctx.Response.Headers.TryExtractRetryAfterTime(out var retryTime);
+            return retryTime;
+        }
+
+        /// <summary>
+        /// Provides the default backoff strategy when no custom strategy is specified.
+        /// </summary>
+        /// <param name="ctx">The context containing information about the HTTP response.</param>
+        /// <param name="retryTime">The suggested retry time, if any.</param>
+        /// <returns>An <see cref="IHttpBackoffProvider"/> representing the default backoff strategy.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="ctx"/> is <see langword="null"/>.</exception>
+        protected virtual IHttpBackoffProvider GetDefaultStrategy(HttpResponseErrorContext ctx, DateTimeOffset? retryTime)
+        {
+            if (ctx is null)
+                throw new ArgumentNullException(nameof(ctx));
+
+            return retryTime.HasValue ? BackoffStrategies.Once(retryTime.Value) : ctx.Client.BackoffStrategy;
+        }
+
+        /// <summary>
+        /// Creates a scheduler for retrying the failed request based on the error context.
+        /// </summary>
+        /// <param name="ctx">The context containing information about the HTTP response that indicates a failure.</param>
+        /// <returns>An <see cref="IRetryScheduler"/> that schedules the retry attempts.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="ctx"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// The method uses <see cref="OnBackoffStrategy"/> when available. If the delegate is not provided or returns
+        /// <see langword="null"/>, and the response includes a suggested retry time, a single retry at that time is used.
+        /// Otherwise the client's default backoff strategy is used.
+        /// </remarks>
+        protected virtual IRetryScheduler? CreateScheduler(HttpResponseErrorContext ctx)
+        {
+            if (ctx is null)
+                throw new ArgumentNullException(nameof(ctx));
+
+            var retryTime = GetSuggestedRetryTime(ctx);
+            var strategy = OnBackoffStrategy?.Invoke(ctx, retryTime) ?? GetDefaultStrategy(ctx, retryTime);
+            return strategy.CreateScheduler(ctx);
+        }
+
+        /// <inheritdoc/>
+        Task<HttpErrorHandlerResult> IHttpErrorHandler.DecideOnRetryAsync(HttpResponseErrorContext ctx, CancellationToken cancellationToken)
+        {
+            return ctx.ScheduleRetryAsync(CreateScheduler, cancellationToken);
+        }
+    }
+}

--- a/src/Kampute.HttpClient/ErrorHandlers/Abstracts/RetryableHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/Abstracts/RetryableHttpErrorHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/DynamicHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/DynamicHttpErrorHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/HttpError401Handler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/HttpError401Handler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/HttpError429Handler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/HttpError429Handler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/HttpError429Handler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/HttpError429Handler.cs
@@ -5,11 +5,10 @@
 
 namespace Kampute.HttpClient.ErrorHandlers
 {
+    using Kampute.HttpClient.ErrorHandlers.Abstracts;
     using Kampute.HttpClient.Interfaces;
     using System;
     using System.Net;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Handles '429 Too Many Requests' HTTP responses by attempting to back off and retry the request according to a specified or
@@ -17,92 +16,41 @@ namespace Kampute.HttpClient.ErrorHandlers
     /// </summary>
     /// <remarks>
     /// This handler provides a mechanism to respond to HTTP 429 errors by retrying the request after a delay. The delay duration and
-    /// retry logic can be customized through the <see cref="OnBackoffStrategy"/> delegate. If the delegate is not provided, or does not
-    /// specify a strategy, the handler will look for a rate limit reset header in the response. If the header is present, its value is
-    /// used to determine the backoff duration. If the header is not present, no retries will be attempted.
+    /// retry logic can be customized through the <see cref="RetryableHttpErrorHandler.OnBackoffStrategy"/> delegate. If the delegate
+    /// is not provided, or does not specify a strategy, the handler will look for a rate limit reset header in the response. If the
+    /// header is present, its value is used to determine the backoff duration. If the header is not present, no retries will be attempted.
     /// </remarks>
     /// <seealso cref="HttpRestClient.ErrorHandlers"/>
-    public class HttpError429Handler : IHttpErrorHandler
+    public class HttpError429Handler : RetryableHttpErrorHandler
     {
-        /// <summary>
-        /// A delegate that allows customization of the backoff strategy when a 429 Too Many Requests' response is received.
-        /// </summary>
-        /// <value>
-        /// A function that takes an <see cref="HttpResponseErrorContext"/> and an optional <see cref="DateTimeOffset"/> representing
-        /// the rate limit reset time, and returns an <see cref="IHttpBackoffProvider"/> to define the backoff strategy.
-        /// </value>
-        /// <remarks>
-        /// <para>
-        /// If this delegate is set and returns an <see cref="IHttpBackoffProvider"/>, the returned strategy is used for the retry operation.
-        /// If it is not set, or returns <see langword="null"/>, the handler will defer to the <c>Retry-After</c> header in the response.
-        /// </para>
-        /// <para>
-        /// The delegate receives the following parameters:
-        /// <list type="bullet">
-        ///   <item>
-        ///     <term>context</term>
-        ///     <description>
-        ///     Provides context about the HTTP response indicating a '429 Too Many Requests' error. It is encapsulated within
-        ///     an <see cref="HttpResponseErrorContext"/> instance, allowing for an informed decision on the retry strategy.
-        ///     </description>
-        ///   </item>
-        ///   <item>
-        ///     <term>resetTime</term>
-        ///     <description>
-        ///     Indicates the time when the rate limit will be lifted as a <see cref="DateTimeOffset"/> value. If the server specifies
-        ///     a reset time via response headers, this parameter provides that time, allowing the client to know when to resume requests.
-        ///     If the server does not specify a reset time, the value will be <see langword="null"/>.
-        ///     </description>
-        ///   </item>
-        /// </list>
-        /// </para>
-        /// </remarks>
-        public Func<HttpResponseErrorContext, DateTimeOffset?, IHttpBackoffProvider?>? OnBackoffStrategy { get; set; }
-
-        /// <summary>
-        /// Determines whether this handler can process the specified HTTP status code.
-        /// </summary>
-        /// <param name="statusCode">The HTTP status code to evaluate.</param>
-        /// <returns><see langword="true"/> if the handler can process the status code; otherwise, <see langword="false"/>.</returns>
+        /// <inheritdoc/>
         /// <remarks>
         /// This implementation specifically handles the HTTP '429 Too Many Requests' status code.
         /// </remarks>
-        public bool CanHandle(HttpStatusCode statusCode) =>
+        public sealed override bool CanHandle(HttpStatusCode statusCode) =>
 #if NETSTANDARD2_1_OR_GREATER
             statusCode == HttpStatusCode.TooManyRequests;
 #else
             statusCode == (HttpStatusCode)429;
 #endif
 
-        /// <summary>
-        /// Creates a scheduler for retrying the failed request based on the error context.
-        /// </summary>
-        /// <param name="ctx">The context containing information about the HTTP response that indicates a failure.</param>
-        /// <returns>An <see cref="IRetryScheduler"/> that schedules the retry attempts.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="ctx"/> is <see langword="null"/>.</exception>
-        /// <remarks>
-        /// This method first attempts to use the <see cref="OnBackoffStrategy"/> delegate to obtain a retry strategy. If the delegate is not
-        /// provided or returns <see langword="null"/>, and a rate limit reset header is present, the value of this header is used to create a retry delay.
-        /// If neither condition is met, no retries will be attempted.
-        /// </remarks>
-        protected virtual IRetryScheduler? CreateScheduler(HttpResponseErrorContext ctx)
+        /// <inheritdoc/>
+        protected override DateTimeOffset? GetSuggestedRetryTime(HttpResponseErrorContext ctx)
         {
             if (ctx is null)
                 throw new ArgumentNullException(nameof(ctx));
 
             ctx.Response.Headers.TryExtractRateLimitResetTime(out var resetTime);
-
-            var strategy = OnBackoffStrategy?.Invoke(ctx, resetTime);
-            if (strategy is null && resetTime is DateTimeOffset retryAfter)
-                strategy = BackoffStrategies.Once(retryAfter);
-
-            return strategy?.CreateScheduler(ctx);
+            return resetTime;
         }
 
         /// <inheritdoc/>
-        Task<HttpErrorHandlerResult> IHttpErrorHandler.DecideOnRetryAsync(HttpResponseErrorContext ctx, CancellationToken cancellationToken)
+        protected override IHttpBackoffProvider GetDefaultStrategy(HttpResponseErrorContext ctx, DateTimeOffset? retryTime)
         {
-            return ctx.ScheduleRetryAsync(CreateScheduler, cancellationToken);
+            if (ctx is null)
+                throw new ArgumentNullException(nameof(ctx));
+
+            return retryTime.HasValue ? BackoffStrategies.Once(retryTime.Value) : BackoffStrategies.None;
         }
     }
 }

--- a/src/Kampute.HttpClient/ErrorHandlers/HttpError503Handler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/HttpError503Handler.cs
@@ -5,100 +5,35 @@
 
 namespace Kampute.HttpClient.ErrorHandlers
 {
-    using Kampute.HttpClient.Interfaces;
-    using System;
+    using Kampute.HttpClient.ErrorHandlers.Abstracts;
     using System.Net;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Handles '503 Service Unavailable' HTTP responses by attempting to back off and retry the request according to a specified or
     /// default backoff strategy.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// This handler provides a mechanism to respond to HTTP 503 errors by retrying the request after a delay. The delay duration and
-    /// retry logic can be customized through the <see cref="OnBackoffStrategy"/> delegate. If the delegate is not provided, or does not
-    /// specify a strategy, the handler will look for a <c>Retry-After</c> header in the response. If the <c>Retry-After</c> header is
-    /// present, its value is used to determine the backoff duration. If the header is not present, the default backoff strategy of the
-    /// <see cref="HttpRestClient"/> is used.
+    /// retry logic can be customized through the <see cref="RetryableHttpErrorHandler.OnBackoffStrategy"/> delegate. If the delegate
+    /// is not provided, or does not specify a strategy, the handler will look for a <c>Retry-After</c> header in the response. If the
+    /// <c>Retry-After</c> header is present, its value is used to determine the backoff duration. If the header is not present, the
+    /// default backoff strategy of the <see cref="HttpRestClient"/> is used.
+    /// </para>
+    /// <note type="hint" title="Hint">
+    /// Consider using <see cref="TransientHttpErrorHandler"/> if you want to handle multiple transient HTTP errors (including 503) with
+    /// a single handler.
+    /// </note>
     /// </remarks>
     /// <seealso cref="HttpRestClient.ErrorHandlers"/>
     /// <seealso cref="HttpRestClient.BackoffStrategy"/>
-    public class HttpError503Handler : IHttpErrorHandler
+    /// <seealso cref="TransientHttpErrorHandler"/>
+    public class HttpError503Handler : RetryableHttpErrorHandler
     {
-        /// <summary>
-        /// A delegate that allows customization of the backoff strategy when a '503 Service Unavailable' response is received.
-        /// </summary>
-        /// <value>
-        /// A function that takes an <see cref="HttpResponseErrorContext"/> and an optional <see cref="DateTimeOffset"/> representing
-        /// the suggested retry time from the <c>Retry-After</c> header, and returns an <see cref="IHttpBackoffProvider"/> to be used
-        /// for the retry operation.
-        /// </value>
-        /// <remarks>
-        /// <para>
-        /// If this delegate is set and returns an <see cref="IHttpBackoffProvider"/>, the returned strategy is used for the retry operation.
-        /// If it is not set, or returns <see langword="null"/>, the handler will defer to the <c>Retry-After</c> header in the response or the
-        /// client's default backoff strategy.
-        /// </para>
-        /// <para>
-        /// The delegate receives the following parameters:
-        /// <list type="bullet">
-        ///   <item>
-        ///     <term>context</term>
-        ///     <description>
-        ///     Provides context about the HTTP response indicating a '503 Service Unavailable' error. It is encapsulated within
-        ///     an <see cref="HttpResponseErrorContext"/> instance, allowing for an informed decision on the retry strategy.
-        ///     </description>
-        ///   </item>
-        ///   <item>
-        ///     <term>retryAfter</term>
-        ///     <description>
-        ///       Advises on the next retry attempt timing as a <see cref="DateTimeOffset"/> value. If the response includes a <c>Retry-After</c>
-        ///       header, this parameter reflects its value, suggesting an optimal time to retry. If the header is missing, the value is <see langword="null"/>,
-        ///       indicating no specific suggestion from the server.
-        ///     </description>
-        ///   </item>
-        /// </list>
-        /// </para>
-        /// </remarks>
-        public Func<HttpResponseErrorContext, DateTimeOffset?, IHttpBackoffProvider?>? OnBackoffStrategy { get; set; }
-
-        /// <summary>
-        /// Determines whether this handler can process the specified HTTP status code.
-        /// </summary>
-        /// <param name="statusCode">The HTTP status code to evaluate.</param>
-        /// <returns><see langword="true"/> if the handler can process the status code; otherwise, <see langword="false"/>.</returns>
+        /// <inheritdoc/>
         /// <remarks>
         /// This implementation specifically handles the HTTP '503 Service Unavailable' status code.
         /// </remarks>
-        public virtual bool CanHandle(HttpStatusCode statusCode) => statusCode == HttpStatusCode.ServiceUnavailable;
-
-        /// <summary>
-        /// Creates a scheduler for retrying the failed request based on the error context.
-        /// </summary>
-        /// <param name="ctx">The context containing information about the HTTP response that indicates a failure.</param>
-        /// <returns>An <see cref="IRetryScheduler"/> that schedules the retry attempts.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="ctx"/> is <see langword="null"/>.</exception>
-        /// <remarks>
-        /// This method first attempts to use the <see cref="OnBackoffStrategy"/> delegate to obtain a retry strategy. If the delegate is not
-        /// provided or returns <see langword="null"/>, and a <c>Retry-After</c> header is present, the value of this header is used to create a retry
-        /// delay. If neither condition is met, the client's default backoff strategy is utilized.
-        /// </remarks>
-        protected virtual IRetryScheduler? CreateScheduler(HttpResponseErrorContext ctx)
-        {
-            if (ctx is null)
-                throw new ArgumentNullException(nameof(ctx));
-
-            ctx.Response.Headers.TryExtractRetryAfterTime(out var retryAfter);
-
-            var strategy = OnBackoffStrategy?.Invoke(ctx, retryAfter) ?? (retryAfter.HasValue ? BackoffStrategies.Once(retryAfter.Value) : ctx.Client.BackoffStrategy);
-            return strategy.CreateScheduler(ctx);
-        }
-
-        /// <inheritdoc/>
-        Task<HttpErrorHandlerResult> IHttpErrorHandler.DecideOnRetryAsync(HttpResponseErrorContext ctx, CancellationToken cancellationToken)
-        {
-            return ctx.ScheduleRetryAsync(CreateScheduler, cancellationToken);
-        }
+        public sealed override bool CanHandle(HttpStatusCode statusCode) => statusCode == HttpStatusCode.ServiceUnavailable;
     }
 }

--- a/src/Kampute.HttpClient/ErrorHandlers/HttpError503Handler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/HttpError503Handler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/ErrorHandlers/TransientHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/TransientHttpErrorHandler.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (C) 2024 Kampute
+//
+// This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
+// See the LICENSE file in the project root for the full license text.
+
+namespace Kampute.HttpClient.ErrorHandlers
+{
+    using Kampute.HttpClient.ErrorHandlers.Abstracts;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+
+    /// <summary>
+    /// Handles HTTP responses with a transient error status code by attempting to back off and retry the request according to a specified
+    /// or default backoff strategy.
+    /// </summary>
+    /// <seealso cref="HttpRestClient.ErrorHandlers"/>
+    /// <seealso cref="HttpRestClient.BackoffStrategy"/>
+    public class TransientHttpErrorHandler : RetryableHttpErrorHandler
+    {
+        private readonly HashSet<HttpStatusCode> _handledStatusCodes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransientHttpErrorHandler"/> class with default transient error status codes.
+        /// </summary>
+        /// <remarks>
+        /// The default transient error status codes handled by this instance are:
+        /// <list type="bullet">
+        ///   <item><term>408</term><description>Request Timeout</description></item>
+        ///   <item><term>502</term><description>Bad Gateway</description></item>
+        ///   <item><term>503</term><description>Service Unavailable</description></item>
+        ///   <item><term>504</term><description>Gateway Timeout</description></item>
+        ///   <item><term>507</term><description>Insufficient Storage</description></item>
+        ///   <item><term>509</term><description>Bandwidth Limit Exceeded</description></item>
+        /// </list>
+        /// </remarks>
+        public TransientHttpErrorHandler()
+        {
+            _handledStatusCodes =
+            [
+                HttpStatusCode.RequestTimeout,     // 408 - Request Timeout
+                HttpStatusCode.BadGateway,         // 502 - Bad Gateway
+                HttpStatusCode.ServiceUnavailable, // 503 - Service Unavailable
+                HttpStatusCode.GatewayTimeout,     // 504 - Gateway Timeout
+                (HttpStatusCode) 507,              // 507 - Insufficient Storage
+                (HttpStatusCode) 509,              // 509 - Bandwidth Limit Exceeded
+            ];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransientHttpErrorHandler"/> class with specified transient error status codes.
+        /// </summary>
+        /// <param name="statusCodes">The collection of HTTP status codes that this handler will process as transient errors.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="statusCodes"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="statusCodes"/> is empty.</exception>
+        public TransientHttpErrorHandler(IEnumerable<HttpStatusCode> statusCodes)
+        {
+            if (statusCodes is null)
+                throw new ArgumentNullException(nameof(statusCodes));
+
+            _handledStatusCodes = [.. statusCodes];
+            if (_handledStatusCodes.Count == 0)
+                throw new ArgumentException("At least one status code must be provided.", nameof(statusCodes));
+        }
+
+        /// <summary>
+        /// Gets the collection of HTTP status codes that are considered transient errors and handled by this instance.
+        /// </summary>
+        /// <value>
+        /// A read-only collection of <see cref="HttpStatusCode"/> values that are treated as transient errors.
+        /// </value>
+        public IReadOnlyCollection<HttpStatusCode> HandledStatusCodes => _handledStatusCodes;
+
+        /// <inheritdoc/>
+        public sealed override bool CanHandle(HttpStatusCode statusCode) => _handledStatusCodes.Contains(statusCode);
+    }
+}

--- a/src/Kampute.HttpClient/ErrorHandlers/TransientHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/ErrorHandlers/TransientHttpErrorHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpContentDeserializerCollection.cs
+++ b/src/Kampute.HttpClient/HttpContentDeserializerCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpContentException.cs
+++ b/src/Kampute.HttpClient/HttpContentException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpContentExtensions.cs
+++ b/src/Kampute.HttpClient/HttpContentExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
+++ b/src/Kampute.HttpClient/HttpErrorHandlerCollection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpErrorHandlerResult.cs
+++ b/src/Kampute.HttpClient/HttpErrorHandlerResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRequestErrorContext.cs
+++ b/src/Kampute.HttpClient/HttpRequestErrorContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRequestMessageCloneManager.cs
+++ b/src/Kampute.HttpClient/HttpRequestMessageCloneManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRequestMessageCloneManager.cs
+++ b/src/Kampute.HttpClient/HttpRequestMessageCloneManager.cs
@@ -70,12 +70,13 @@ namespace Kampute.HttpClient
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private readonly void DisposeNonOriginalRequest()
         {
-            if (!ReferenceEquals(_currentRequest, _originalRequest))
-            {
-                if (_currentRequest.IsCloned())
-                    _currentRequest.Content = null; // Content is reused, not cloned.
-                _currentRequest.Dispose();
-            }
+            if (ReferenceEquals(_currentRequest, _originalRequest))
+                return;
+
+            if (_currentRequest.IsCloned())
+                _currentRequest.Content = null; // Content is reused, not cloned.
+
+            _currentRequest.Dispose();
         }
     }
 }

--- a/src/Kampute.HttpClient/HttpRequestMessageEventArgs.cs
+++ b/src/Kampute.HttpClient/HttpRequestMessageEventArgs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRequestMessageExtensions.cs
+++ b/src/Kampute.HttpClient/HttpRequestMessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRequestMessagePropertyKeys.cs
+++ b/src/Kampute.HttpClient/HttpRequestMessagePropertyKeys.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpResponseErrorContext.cs
+++ b/src/Kampute.HttpClient/HttpResponseErrorContext.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpResponseException.cs
+++ b/src/Kampute.HttpClient/HttpResponseException.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpResponseHeadersExtensions.cs
+++ b/src/Kampute.HttpClient/HttpResponseHeadersExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpResponseMessageEventArgs.cs
+++ b/src/Kampute.HttpClient/HttpResponseMessageEventArgs.cs
@@ -1,5 +1,5 @@
 ﻿
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRestClient.cs
+++ b/src/Kampute.HttpClient/HttpRestClient.cs
@@ -484,11 +484,11 @@ namespace Kampute.HttpClient
             if (response is null)
                 throw new ArgumentNullException(nameof(response));
 
-            var context = new HttpResponseErrorContext(this, request, response, error);
+            var ctx = new HttpResponseErrorContext(this, request, response, error);
 
             foreach (var errorHandler in ErrorHandlers.GetHandlersFor(response.StatusCode))
             {
-                var decision = await errorHandler.DecideOnRetryAsync(context, cancellationToken).ConfigureAwait(false);
+                var decision = await errorHandler.DecideOnRetryAsync(ctx, cancellationToken).ConfigureAwait(false);
                 if (decision.RequestToRetry is not null)
                 {
                     decision.RequestToRetry.Properties[HttpRequestMessagePropertyKeys.ErrorHandler] = errorHandler;

--- a/src/Kampute.HttpClient/HttpRestClient.cs
+++ b/src/Kampute.HttpClient/HttpRestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRestClientExtensions.cs
+++ b/src/Kampute.HttpClient/HttpRestClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpRestClientFormExtensions.cs
+++ b/src/Kampute.HttpClient/HttpRestClientFormExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/HttpVerb.cs
+++ b/src/Kampute.HttpClient/HttpVerb.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/IHttpBackoffProvider.cs
+++ b/src/Kampute.HttpClient/Interfaces/IHttpBackoffProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/IHttpContentDeserializer.cs
+++ b/src/Kampute.HttpClient/Interfaces/IHttpContentDeserializer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/IHttpErrorHandler.cs
+++ b/src/Kampute.HttpClient/Interfaces/IHttpErrorHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/IHttpErrorResponse.cs
+++ b/src/Kampute.HttpClient/Interfaces/IHttpErrorResponse.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/IRetryScheduler.cs
+++ b/src/Kampute.HttpClient/Interfaces/IRetryScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Interfaces/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Interfaces/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Kampute.HttpClient.csproj
+++ b/src/Kampute.HttpClient/Kampute.HttpClient.csproj
@@ -5,9 +5,9 @@
     <Title>Kampute.HttpClient</Title>
     <Description>Kampute.HttpClient is a versatile and lightweight .NET library that simplifies RESTful API communication. Its core HttpRestClient class provides a streamlined approach to HTTP interactions, offering advanced features such as flexible serialization/deserialization, robust error handling, configurable backoff strategies, and detailed request-response processing. Striking a balance between simplicity and extensibility, Kampute.HttpClient empowers developers with a powerful yet easy-to-use client for seamless API integration across a wide range of .NET applications.</Description>
     <Authors>Kambiz Khojasteh</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Company>Kampute</Company>
-    <Copyright>Copyright (c) 2024 Kampute</Copyright>
+    <Copyright>Copyright (c) 2025 Kampute</Copyright>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Kampute.HttpClient/MediaTypeNames.cs
+++ b/src/Kampute.HttpClient/MediaTypeNames.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/BackoffStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/BackoffStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/DynamicBackoffStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/DynamicBackoffStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/RetryManagement/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/RetryScheduler.cs
+++ b/src/Kampute.HttpClient/RetryManagement/RetryScheduler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/ExponentialStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/ExponentialStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/FibonacciStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/FibonacciStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/LinearStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/LinearStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/Modifiers/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/Modifiers/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/NoneStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/NoneStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/RetryManagement/Strategies/UniformStrategy.cs
+++ b/src/Kampute.HttpClient/RetryManagement/Strategies/UniformStrategy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Utilities/ExceptionExtensions.cs
+++ b/src/Kampute.HttpClient/Utilities/ExceptionExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Utilities/NamespaceDoc.cs
+++ b/src/Kampute.HttpClient/Utilities/NamespaceDoc.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/src/Kampute.HttpClient/Utilities/SharedDisposable.cs
+++ b/src/Kampute.HttpClient/Utilities/SharedDisposable.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (C) 2024 Kampute
+﻿// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/tests/Kampute.HttpClient.DataContract.Test/HttpRestClientXmlExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.DataContract.Test/HttpRestClientXmlExtensionsTests.cs
@@ -62,12 +62,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -89,12 +89,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -116,12 +116,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {

--- a/tests/Kampute.HttpClient.DataContract.Test/Kampute.HttpClient.DataContract.Test.csproj
+++ b/tests/Kampute.HttpClient.DataContract.Test/Kampute.HttpClient.DataContract.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	<LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Kampute.HttpClient.DataContract.Test/XmlContentTests.cs
+++ b/tests/Kampute.HttpClient.DataContract.Test/XmlContentTests.cs
@@ -17,12 +17,12 @@
 
             var xmlString = await xmlContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(xmlString, Is.EqualTo(expectedString));
                 Assert.That(xmlContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
                 Assert.That(xmlContent.Headers.ContentType?.CharSet, Is.EqualTo(Encoding.UTF8.WebName));
-            });
+            }
         }
 
         [Test]
@@ -36,12 +36,12 @@
 
             var xmlString = await xmlContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(xmlString, Is.EqualTo(expectedString));
                 Assert.That(xmlContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
                 Assert.That(xmlContent.Headers.ContentType?.CharSet, Is.EqualTo(encoding.WebName));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Json.Test/HttpRestClientJsonExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.Json.Test/HttpRestClientJsonExtensionsTests.cs
@@ -63,12 +63,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -90,12 +90,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -117,12 +117,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {

--- a/tests/Kampute.HttpClient.Json.Test/JsonContentTests.cs
+++ b/tests/Kampute.HttpClient.Json.Test/JsonContentTests.cs
@@ -17,12 +17,12 @@
 
             var jsonString = await jsonContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(jsonString, Is.EqualTo(expectedString));
                 Assert.That(jsonContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
                 Assert.That(jsonContent.Headers.ContentType?.CharSet, Is.EqualTo(Encoding.UTF8.WebName));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Json.Test/Kampute.HttpClient.Json.Test.csproj
+++ b/tests/Kampute.HttpClient.Json.Test/Kampute.HttpClient.Json.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	<LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Kampute.HttpClient.NewtonsoftJson.Test/HttpRestClientJsonExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.NewtonsoftJson.Test/HttpRestClientJsonExtensionsTests.cs
@@ -63,12 +63,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -90,12 +90,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -117,12 +117,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
-                });
+                }
 
                 return new HttpResponseMessage
                 {

--- a/tests/Kampute.HttpClient.NewtonsoftJson.Test/JsonContentTests.cs
+++ b/tests/Kampute.HttpClient.NewtonsoftJson.Test/JsonContentTests.cs
@@ -17,12 +17,12 @@
 
             var jsonString = await jsonContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(jsonString, Is.EqualTo(expectedString));
                 Assert.That(jsonContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Json));
                 Assert.That(jsonContent.Headers.ContentType?.CharSet, Is.EqualTo(Encoding.UTF8.WebName));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.NewtonsoftJson.Test/Kampute.HttpClient.NewtonsoftJson.Test.csproj
+++ b/tests/Kampute.HttpClient.NewtonsoftJson.Test/Kampute.HttpClient.NewtonsoftJson.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	<LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Kampute.HttpClient.Test/Content/Compression/DeflateCompressedContentTests.cs
+++ b/tests/Kampute.HttpClient.Test/Content/Compression/DeflateCompressedContentTests.cs
@@ -19,11 +19,11 @@
             using var originalContent = new StringContent(text, Encoding.UTF32, MediaTypeNames.Text.Plain);
             using var compressedContent = new DeflateCompressedContent(originalContent, CompressionLevel.Optimal);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(compressedContent.Headers.ContentType, Is.EqualTo(originalContent.Headers.ContentType));
                 Assert.That(compressedContent.Headers.ContentEncoding, Contains.Item("deflate"));
-            });
+            }
 
             var compressedStream = await compressedContent.ReadAsStreamAsync();
 

--- a/tests/Kampute.HttpClient.Test/Content/Compression/GzipCompressedContentTests.cs
+++ b/tests/Kampute.HttpClient.Test/Content/Compression/GzipCompressedContentTests.cs
@@ -19,11 +19,11 @@
             using var originalContent = new StringContent(text, Encoding.UTF32, MediaTypeNames.Text.Plain);
             using var compressedContent = new GzipCompressedContent(originalContent, CompressionLevel.Optimal);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(compressedContent.Headers.ContentType, Is.EqualTo(originalContent.Headers.ContentType));
                 Assert.That(compressedContent.Headers.ContentEncoding, Contains.Item("gzip"));
-            });
+            }
 
             var compressedStream = await compressedContent.ReadAsStreamAsync();
 

--- a/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError401HandlerTests.cs
+++ b/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError401HandlerTests.cs
@@ -67,17 +67,17 @@
             var tasks = Enumerable.Range(1, numberOfRequests).Select(i => _client.SendAsync(HttpMethod.Get, $"/protected/resource{i}"));
             await Task.WhenAll(tasks);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(numberOfInvokes, Is.EqualTo(1));
                 Assert.That(numberOfResponses, Is.EqualTo(numberOfRequests + 1));
                 Assert.That(_client.DefaultRequestHeaders.Authorization, Is.Not.Null);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(_client.DefaultRequestHeaders.Authorization?.Scheme, Is.EqualTo(scheme));
                     Assert.That(_client.DefaultRequestHeaders.Authorization?.Parameter, Is.EqualTo(apiKey));
-                });
-            });
+                }
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError429HandlerTests.cs
+++ b/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError429HandlerTests.cs
@@ -54,11 +54,11 @@
             await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/rate-limited/resource"), Throws.TypeOf<HttpResponseException>());
             timer.Stop();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(attempts, Is.EqualTo(2));
                 Assert.That(timer.Elapsed, Is.EqualTo(resetDelay).Within(TimeSpan.FromSeconds(1.0)));
-            });
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError503HandlerTests.cs
+++ b/tests/Kampute.HttpClient.Test/ErrorHandlers/HttpError503HandlerTests.cs
@@ -55,11 +55,11 @@
             await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
             timer.Stop();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(attempts, Is.EqualTo(2));
                 Assert.That(timer.Elapsed, Is.EqualTo(retryDelay).Within(0.1 * retryDelay));
-            });
+            }
         }
 
         [Test]
@@ -84,11 +84,11 @@
             await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
             timer.Stop();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(attempts, Is.EqualTo(2));
                 Assert.That(timer.Elapsed, Is.EqualTo(retryDelay).Within(0.1 * retryDelay));
-            });
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/ErrorHandlers/TransientHttpErrorHandlerTests.cs
+++ b/tests/Kampute.HttpClient.Test/ErrorHandlers/TransientHttpErrorHandlerTests.cs
@@ -1,0 +1,187 @@
+// Copyright (C) 2024 Kampute
+//
+// This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
+// See the LICENSE file in the project root for the full license text.
+
+namespace Kampute.HttpClient.Test.ErrorHandlers
+{
+    using Kampute.HttpClient.ErrorHandlers;
+    using Kampute.HttpClient.Test.TestHelpers;
+    using Moq;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class TransientHttpErrorHandlerTests
+    {
+        private readonly Mock<HttpMessageHandler> _mockMessageHandler = new();
+        private HttpRestClient _client;
+
+        [SetUp]
+        public void Setup()
+        {
+            var httpClient = new HttpClient(_mockMessageHandler.Object, disposeHandler: false);
+            _client = new HttpRestClient(httpClient)
+            {
+                BaseAddress = new Uri("http://api.test.com"),
+            };
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            _client.Dispose();
+        }
+
+        [Test]
+        public void Constructor_WithNullStatusCodes_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TransientHttpErrorHandler((IEnumerable<HttpStatusCode>)null!));
+        }
+
+        [Test]
+        public void Constructor_WithEmptyStatusCodes_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TransientHttpErrorHandler([]));
+        }
+
+        [Test]
+        public void Constructor_WithCustomStatusCodes_SetsHandledStatusCodes()
+        {
+            var customCodes = new[]
+            {
+                HttpStatusCode.InternalServerError,
+                HttpStatusCode.BadRequest
+            };
+            var handler = new TransientHttpErrorHandler(customCodes);
+
+            Assert.That(handler.HandledStatusCodes, Is.EquivalentTo(customCodes));
+        }
+
+        [Test]
+        [TestCase(HttpStatusCode.RequestTimeout, ExpectedResult = true)]
+        [TestCase(HttpStatusCode.BadGateway, ExpectedResult = true)]
+        [TestCase(HttpStatusCode.ServiceUnavailable, ExpectedResult = true)]
+        [TestCase(HttpStatusCode.GatewayTimeout, ExpectedResult = true)]
+        [TestCase(507 /* Insufficient Storage */, ExpectedResult = true)]
+        [TestCase(509 /* Bandwidth Limit Exceeded */, ExpectedResult = true)]
+        [TestCase(HttpStatusCode.OK, ExpectedResult = false)]
+        [TestCase(HttpStatusCode.NotFound, ExpectedResult = false)]
+        [TestCase(HttpStatusCode.InternalServerError, ExpectedResult = false)]
+        [TestCase(HttpStatusCode.Unauthorized, ExpectedResult = false)]
+        [TestCase(HttpStatusCode.Forbidden, ExpectedResult = false)]
+        [TestCase(HttpStatusCode.BadRequest, ExpectedResult = false)]
+        public bool CanHandle_ForDefaultConfiguration_ReturnsExpectedResults(HttpStatusCode statusCode)
+        {
+            var handler = new TransientHttpErrorHandler();
+
+            return handler.CanHandle(statusCode);
+        }
+
+        [Test]
+        public async Task OnTransientHttpError_WithRetryAfterHeader_AsDate_RetriesRequestAfterSpecifiedTime()
+        {
+            var transientHandler = new TransientHttpErrorHandler();
+            _client.ErrorHandlers.Add(transientHandler);
+
+            var retryDelay = TimeSpan.FromMilliseconds(1000);
+
+            var attempts = 0;
+            _mockMessageHandler.MockHttpResponse(request =>
+            {
+                attempts++;
+
+                var response = new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(DateTimeOffset.UtcNow.Add(retryDelay));
+                return response;
+            });
+
+            var timer = Stopwatch.StartNew();
+            await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
+            timer.Stop();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(attempts, Is.EqualTo(2));
+                Assert.That(timer.Elapsed, Is.EqualTo(retryDelay).Within(0.1 * retryDelay));
+            }
+        }
+
+        [Test]
+        public async Task OnTransientHttpError_WithRetryAfterHeader_AsDelta_RetriesRequestAfterSpecifiedDelay()
+        {
+            var transientHandler = new TransientHttpErrorHandler();
+            _client.ErrorHandlers.Add(transientHandler);
+
+            var retryDelay = TimeSpan.FromMilliseconds(1000);
+
+            var attempts = 0;
+            _mockMessageHandler.MockHttpResponse(request =>
+            {
+                attempts++;
+
+                var response = new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+                response.Headers.RetryAfter = new RetryConditionHeaderValue(retryDelay);
+                return response;
+            });
+
+            var timer = Stopwatch.StartNew();
+            await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
+            timer.Stop();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(attempts, Is.EqualTo(2));
+                Assert.That(timer.Elapsed, Is.EqualTo(retryDelay).Within(0.1 * retryDelay));
+            }
+        }
+
+        [Test]
+        public async Task OnTransientHttpError_WithoutRetryAfterHeader_RetriesAccordingToDefaultStrategy()
+        {
+            var transientHandler = new TransientHttpErrorHandler();
+            _client.ErrorHandlers.Add(transientHandler);
+            _client.BackoffStrategy = BackoffStrategies.Uniform(2, TimeSpan.Zero);
+
+            var attempts = 0;
+            _mockMessageHandler.MockHttpResponse(request =>
+            {
+                attempts++;
+
+                return new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+            });
+
+            await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
+
+            Assert.That(attempts, Is.EqualTo(3));
+        }
+
+        [Test]
+        public async Task OnTransientHttpError_WithCustomBackoffStrategy_RetriesAccordingToCustomStrategy()
+        {
+            var transientHandler = new TransientHttpErrorHandler
+            {
+                OnBackoffStrategy = (ctx, retryAfter) => BackoffStrategies.Uniform(2, TimeSpan.Zero)
+            };
+            _client.ErrorHandlers.Add(transientHandler);
+
+            var attempts = 0;
+            _mockMessageHandler.MockHttpResponse(request =>
+            {
+                attempts++;
+
+                return new HttpResponseMessage(HttpStatusCode.RequestTimeout);
+            });
+
+            await Assert.ThatAsync(() => _client.SendAsync(HttpMethod.Get, "/unavailable/resource"), Throws.TypeOf<HttpResponseException>());
+
+            Assert.That(attempts, Is.EqualTo(3));
+        }
+    }
+}

--- a/tests/Kampute.HttpClient.Test/ErrorHandlers/TransientHttpErrorHandlerTests.cs
+++ b/tests/Kampute.HttpClient.Test/ErrorHandlers/TransientHttpErrorHandlerTests.cs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 Kampute
+// Copyright (C) 2025 Kampute
 //
 // This file is part of the Kampute.HttpClient package and is released under the terms of the MIT license.
 // See the LICENSE file in the project root for the full license text.

--- a/tests/Kampute.HttpClient.Test/HttpContentDeserializerCollectionTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpContentDeserializerCollectionTests.cs
@@ -99,11 +99,11 @@
 
             var result = collection.Remove(deserializer);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(collection, Is.Empty);
-            });
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/HttpErrorHandlerCollectionTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpErrorHandlerCollectionTests.cs
@@ -53,11 +53,11 @@
 
             var result = collection.Remove(errorHandler);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(collection, Is.Empty);
-            });
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/HttpRequestScopeTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpRequestScopeTests.cs
@@ -91,12 +91,12 @@
             _mockMessageHandler.MockHttpResponse(request =>
             {
                 var propExists = request.Options.TryGetValue(new HttpRequestOptionsKey<string>(propertyName), out var propValue);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(propExists, Is.True);
                     Assert.That(propValue, Is.EqualTo(propertyValue));
-                    Assert.That(request.Headers.GetValues(headerName), Is.EqualTo(new[] { headerValue }));
-                });
+                    Assert.That(request.Headers.GetValues(headerName), Is.EqualTo([headerValue]));
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });

--- a/tests/Kampute.HttpClient.Test/HttpResponseHeadersExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpResponseHeadersExtensionsTests.cs
@@ -25,11 +25,11 @@
 
             var result = _headers.TryExtractRetryAfterTime(out var retryAfterTime);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(retryAfterTime, Is.EqualTo(expectedDate).Within(TimeSpan.FromSeconds(1)));
-            });
+            }
         }
 
         [Test]
@@ -40,11 +40,11 @@
 
             var result = _headers.TryExtractRetryAfterTime(out var retryAfterTime);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(retryAfterTime, Is.EqualTo(DateTimeOffset.UtcNow.Add(delta)).Within(TimeSpan.FromSeconds(1)));
-            });
+            }
         }
 
         [Test]
@@ -52,11 +52,11 @@
         {
             var result = _headers.TryExtractRetryAfterTime(out var retryAfterTime);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(retryAfterTime, Is.Null);
-            });
+            }
         }
 
         [Test]
@@ -67,11 +67,11 @@
 
             var result = _headers.TryExtractRateLimitResetTime(out var resetTime);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(resetTime, Is.EqualTo(expectedTime).Within(TimeSpan.FromSeconds(1)));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/HttpRestClientExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpRestClientExtensionsTests.cs
@@ -47,11 +47,11 @@
         {
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Head));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
@@ -66,11 +66,11 @@
         {
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Options));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
@@ -87,11 +87,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -112,11 +112,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -137,11 +137,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -162,11 +162,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -187,11 +187,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Get));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -214,12 +214,12 @@
             var sent = false;
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 sent = true;
                 return new HttpResponseMessage(HttpStatusCode.OK);
@@ -238,12 +238,12 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -265,12 +265,12 @@
             var sent = false;
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 sent = true;
                 return new HttpResponseMessage(HttpStatusCode.OK);
@@ -278,7 +278,7 @@
 
             await _client.PutAsync("/resource", new TestContent(payload));
 
-            Assert.That(sent, Is.EqualTo(true));
+            Assert.That(sent, Is.True);
         }
 
         [Test]
@@ -289,12 +289,12 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -316,12 +316,12 @@
             var sent = false;
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 sent = true;
                 return new HttpResponseMessage(HttpStatusCode.OK);
@@ -329,7 +329,7 @@
 
             await _client.PatchAsync("/resource", new TestContent(payload));
 
-            Assert.That(sent, Is.EqualTo(true));
+            Assert.That(sent, Is.True);
         }
 
         [Test]
@@ -340,12 +340,12 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo(payload));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -366,11 +366,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Delete));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -391,11 +391,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Delete));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -418,11 +418,11 @@
 
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(method));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
-                });
+                }
 
                 var content = new ByteArrayContent(expectedStream.ToArray());
                 content.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Octet);
@@ -437,21 +437,21 @@
             using var resultStream = await _client.DownloadAsync(method, "/resource", new TestContent(payload), contentHeaders =>
             {
                 Assert.That(contentHeaders, Is.Not.Null);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(contentHeaders.ContentType, Is.EqualTo(new MediaTypeHeaderValue(MediaTypeNames.Application.Octet)));
                     Assert.That(contentHeaders.ContentLength, Is.EqualTo(expectedStream.Length));
-                });
+                }
                 return new MemoryStream((int)contentHeaders.ContentLength.GetValueOrDefault());
             });
 
             Assert.That(resultStream, Is.Not.Null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 resultStream.Seek(0, SeekOrigin.Begin);
                 Assert.That(resultStream, Is.TypeOf<MemoryStream>());
                 Assert.That(resultStream, Is.EqualTo(expectedStream));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/HttpRestClientFormExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.Test/HttpRestClientFormExtensionsTests.cs
@@ -44,13 +44,13 @@
         {
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.FormUrlEncoded));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo("name=value"));
-                });
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
@@ -63,13 +63,13 @@
         {
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.FormUrlEncoded));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo("name=value"));
-                });
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });
@@ -82,13 +82,13 @@
         {
             _mockMessageHandler.MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/resource")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.FormUrlEncoded));
                     Assert.That(request.Content?.ReadAsStringAsync().Result, Is.EqualTo("name=value"));
-                });
+                }
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
             });

--- a/tests/Kampute.HttpClient.Test/Kampute.HttpClient.Test.csproj
+++ b/tests/Kampute.HttpClient.Test/Kampute.HttpClient.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	<LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Kampute.HttpClient.Test/RetryManagement/RetrySchedulerTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/RetrySchedulerTests.cs
@@ -56,11 +56,11 @@
 
             var result = await scheduler.WaitAsync(CancellationToken.None);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(scheduler.Attempts, Is.EqualTo(1u));
-            });
+            }
         }
 
         [Test]
@@ -72,11 +72,11 @@
 
             var result = await scheduler.WaitAsync(CancellationToken.None);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(scheduler.Attempts, Is.Zero);
-            });
+            }
         }
 
         [Test]
@@ -102,11 +102,11 @@
             await scheduler.WaitAsync(CancellationToken.None);
             scheduler.Reset();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(scheduler.Elapsed, Is.LessThanOrEqualTo(TimeSpan.FromMilliseconds(10)));
                 Assert.That(scheduler.Attempts, Is.Zero);
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/ExponentialStrategyTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/ExponentialStrategyTests.cs
@@ -34,11 +34,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
 
         [TestCase(0u, 0, 2.0, 0)]
@@ -57,11 +57,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.FromHours(1), attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/FibonacciStrategyTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/FibonacciStrategyTests.cs
@@ -17,11 +17,11 @@
 
             var strategy = new FibonacciStrategy(initialDelay, delayStep);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(strategy.InitialDelay, Is.EqualTo(initialDelay));
                 Assert.That(strategy.DelayStep, Is.EqualTo(delayStep));
-            });
+            }
         }
 
         [TestCase(0)]
@@ -33,11 +33,11 @@
 
             var strategy = new FibonacciStrategy(initialDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(strategy.InitialDelay, Is.EqualTo(initialDelay));
                 Assert.That(strategy.DelayStep, Is.EqualTo(initialDelay));
-            });
+            }
         }
 
         [TestCase(0u, 0, 0, 0)]
@@ -57,11 +57,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
 
         [TestCase(0u, 0, 0, 0)]
@@ -81,11 +81,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.FromHours(1), attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/LinearStrategyTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/LinearStrategyTests.cs
@@ -17,11 +17,11 @@
 
             var strategy = new LinearStrategy(initialDelay, delayStep);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(strategy.InitialDelay, Is.EqualTo(initialDelay));
                 Assert.That(strategy.DelayStep, Is.EqualTo(delayStep));
-            });
+            }
         }
 
         [TestCase(0)]
@@ -33,11 +33,11 @@
 
             var strategy = new LinearStrategy(initialDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(strategy.InitialDelay, Is.EqualTo(initialDelay));
                 Assert.That(strategy.DelayStep, Is.EqualTo(initialDelay));
-            });
+            }
         }
 
         [TestCase(0u, 0, 0, 0)]
@@ -57,11 +57,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
 
         [TestCase(0u, 0, 0, 0)]
@@ -81,11 +81,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.FromHours(1), attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/JitterStrategyModifierTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/JitterStrategyModifierTests.cs
@@ -32,11 +32,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, 0, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(baseDelay).Within(jitterFactor * baseDelay));
-            });
+            }
         }
 
         [Test]
@@ -48,11 +48,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, 0, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(actualDelay, Is.Default);
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/LimitedAttemptsStrategyModifierTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/LimitedAttemptsStrategyModifierTests.cs
@@ -27,11 +27,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.EqualTo(expectedResult));
                 Assert.That(actualDelay, expectedResult ? Is.Not.Default : Is.Default);
-            });
+            }
         }
 
         [Test]
@@ -44,11 +44,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, 0, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(actualDelay, Is.Default);
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/LimitedDurationStrategyModifierTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/Modifiers/LimitedDurationStrategyModifierTests.cs
@@ -32,11 +32,11 @@
 
             var result = strategy.TryGetRetryDelay(elapsed, 0, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.EqualTo(expectedResult));
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
 
         [Test]
@@ -48,11 +48,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, 0, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(actualDelay, Is.Default);
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/NoneStrategyTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/NoneStrategyTests.cs
@@ -33,11 +33,11 @@
 
             var result = NoneStrategy.Instance.TryGetRetryDelay(elapsed, attempts, out var delay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.False);
                 Assert.That(delay, Is.Default);
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/UniformStrategyTests.cs
+++ b/tests/Kampute.HttpClient.Test/RetryManagement/Strategies/UniformStrategyTests.cs
@@ -27,11 +27,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.Zero, attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
 
         [TestCase(0u)]
@@ -44,11 +44,11 @@
 
             var result = strategy.TryGetRetryDelay(TimeSpan.FromHours(1), attempts, out var actualDelay);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result, Is.True);
                 Assert.That(actualDelay, Is.EqualTo(expectedDelay));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/TestHelpers/TestStream.cs
+++ b/tests/Kampute.HttpClient.Test/TestHelpers/TestStream.cs
@@ -1,0 +1,18 @@
+﻿namespace Kampute.HttpClient.Test.TestHelpers
+{
+    using System;
+    using System.IO;
+
+    internal class TestStream : MemoryStream
+    {
+        private readonly bool seekable;
+
+        public TestStream(bool seekable) : base() => this.seekable = seekable;
+
+        public override bool CanSeek => seekable;
+
+        public override long Seek(long offset, SeekOrigin loc) => seekable
+            ? base.Seek(offset, loc)
+            : throw new NotSupportedException();
+    }
+}

--- a/tests/Kampute.HttpClient.Test/Utilities/AsyncUpdateThrottleTests.cs
+++ b/tests/Kampute.HttpClient.Test/Utilities/AsyncUpdateThrottleTests.cs
@@ -22,11 +22,11 @@
 
             var updateResult = await synchronizer.TryUpdateAsync(() => Task.FromResult(42));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(updateResult, Is.True);
                 Assert.That(synchronizer.Value, Is.EqualTo(42));
-            });
+            }
         }
 
         [Test]
@@ -48,12 +48,12 @@
                 })
             );
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(results[0], Is.True);
                 Assert.That(results[1], Is.False);
                 Assert.That(synchronizer.Value, Is.EqualTo(2));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/Utilities/FlyweightCacheTests.cs
+++ b/tests/Kampute.HttpClient.Test/Utilities/FlyweightCacheTests.cs
@@ -26,11 +26,11 @@
             var result1 = cache.Get(1);
             var result2 = cache.Get(1);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(cache.Count, Is.EqualTo(1));
                 Assert.That(result2, Is.SameAs(result1));
-            });
+            }
         }
 
         [Test]

--- a/tests/Kampute.HttpClient.Test/Utilities/ScopedCollectionTests.cs
+++ b/tests/Kampute.HttpClient.Test/Utilities/ScopedCollectionTests.cs
@@ -17,11 +17,11 @@
 
             using var scope = context.BeginScope(items);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(scope, Is.Not.Null);
                 Assert.That(context, Is.EqualTo(items));
-            });
+            }
         }
 
         [Test]
@@ -113,11 +113,11 @@
 
             var results = await Task.WhenAll(task1, task2);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(results[0], Is.EquivalentTo(expectedProperties1));
                 Assert.That(results[1], Is.EquivalentTo(expectedProperties2));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Test/Utilities/SharedDisposableTests.cs
+++ b/tests/Kampute.HttpClient.Test/Utilities/SharedDisposableTests.cs
@@ -22,11 +22,11 @@
 
             using var reference1 = sharedDisposable.AcquireReference();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(sharedDisposable.ReferenceCount, Is.EqualTo(1));
                 Assert.That(reference1.Instance, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -42,11 +42,11 @@
             using var reference1 = sharedDisposable.AcquireReference();
             using var reference2 = sharedDisposable.AcquireReference();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(sharedDisposable.ReferenceCount, Is.EqualTo(2));
                 Assert.That(factoryInvoked, Is.EqualTo(1));
-            });
+            }
         }
 
         [Test]
@@ -61,18 +61,18 @@
             Assert.That(sharedDisposable.ReferenceCount, Is.EqualTo(2));
 
             reference1.Dispose();
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(sharedDisposable.ReferenceCount, Is.EqualTo(1));
                 Assert.That(instance.IsDisposed, Is.False);
-            });
+            }
 
             reference2.Dispose();
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.That(sharedDisposable.ReferenceCount, Is.EqualTo(0));
+                Assert.That(sharedDisposable.ReferenceCount, Is.Zero);
                 Assert.That(instance.IsDisposed, Is.True);
-            });
+            }
         }
 
         [Test]
@@ -99,11 +99,11 @@
             foreach (var thread in threads)
                 thread.Join();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(sharedDisposable.ReferenceCount, Is.Zero);
                 Assert.That(createdCount, Is.EqualTo(numberOfThreads));
-            });
+            }
         }
     }
 }

--- a/tests/Kampute.HttpClient.Xml.Test/HttpRestClientXmlExtensionsTests.cs
+++ b/tests/Kampute.HttpClient.Xml.Test/HttpRestClientXmlExtensionsTests.cs
@@ -62,12 +62,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Post));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -89,12 +89,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Put));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {
@@ -116,12 +116,12 @@
 
             MockHttpResponse(request =>
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(request.Method, Is.EqualTo(HttpMethod.Patch));
                     Assert.That(request.RequestUri, Is.EqualTo(AbsoluteUrl("/echo")));
                     Assert.That(request.Content?.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
-                });
+                }
 
                 return new HttpResponseMessage
                 {

--- a/tests/Kampute.HttpClient.Xml.Test/Kampute.HttpClient.Xml.Test.csproj
+++ b/tests/Kampute.HttpClient.Xml.Test/Kampute.HttpClient.Xml.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
 	<LangVersion>latest</LangVersion>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Kampute.HttpClient.Xml.Test/XmlContentTests.cs
+++ b/tests/Kampute.HttpClient.Xml.Test/XmlContentTests.cs
@@ -17,12 +17,12 @@
 
             var xmlString = await xmlContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(xmlString, Is.EqualTo(expectedString));
                 Assert.That(xmlContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
                 Assert.That(xmlContent.Headers.ContentType?.CharSet, Is.EqualTo(Encoding.UTF8.WebName));
-            });
+            }
         }
 
         [Test]
@@ -36,12 +36,12 @@
 
             var xmlString = await xmlContent.ReadAsStringAsync();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(xmlString, Is.EqualTo(expectedString));
                 Assert.That(xmlContent.Headers.ContentType?.MediaType, Is.EqualTo(MediaTypeNames.Application.Xml));
                 Assert.That(xmlContent.Headers.ContentType?.CharSet, Is.EqualTo(encoding.WebName));
-            });
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and updates across the codebase, focusing primarily on enhancing HTTP error handling and updating dependencies to support .NET 10.0 and newer library versions. The most significant changes are the introduction of a new abstract base class for retryable HTTP error handling and a refactor of the `HttpError429Handler` to leverage this abstraction. Additionally, there are updates to project metadata and dependency versions, as well as workflow configuration changes.

### HTTP Error Handling Improvements

* Added a new abstract base class `RetryableHttpErrorHandler` in `src/Kampute.HttpClient/ErrorHandlers/Abstracts/RetryableHttpErrorHandler.cs`, which provides a reusable mechanism for handling transient HTTP errors with customizable backoff and retry strategies. This class is designed to be extended for specific error codes and centralizes retry logic.
* Refactored `HttpError429Handler` in `src/Kampute.HttpClient/ErrorHandlers/HttpError429Handler.cs` to inherit from `RetryableHttpErrorHandler`, simplifying its implementation and aligning its retry logic with the new abstraction. The handler now uses a rate limit reset header for retry timing and disables retries if not present.
* Added a documentation-only class `NamespaceDoc` to `src/Kampute.HttpClient/ErrorHandlers/Abstracts/NamespaceDoc.cs` to clarify the purpose of the error handler abstracts namespace.

### Dependency and SDK Updates

* Updated the GitHub Actions workflow in `.github/workflows/main.yml` to use .NET SDK 10.0.x instead of 8.0.x, ensuring compatibility with the latest .NET features.
* Changed package references in project files (`Kampute.HttpClient.Json.csproj`, `Kampute.HttpClient.NewtonsoftJson.csproj`) to use wildcard versions (`10.*` for `System.Text.Json` and `13.*` for `Newtonsoft.Json`), allowing for automatic updates to the latest minor and patch releases. [[1]](diffhunk://#diff-2ee4ab9e1f5c14c19d8e5afe317c9396379fb3209784c6cbe0ad39d763bfd6c2L39-R39) [[2]](diffhunk://#diff-6215240a5f2a08d30bc9d031b739abdb968869584b36553bce92886f72cd64c0L39-R39)

### Project Metadata Updates

* Bumped package versions from `2.4.0` to `2.5.0` and updated copyright years to 2025 in `Kampute.HttpClient.DataContract.csproj`, `Kampute.HttpClient.NewtonsoftJson.csproj`, and `Kampute.HttpClient.Xml.csproj` to reflect the new release. [[1]](diffhunk://#diff-98cfbfd90ea7ec1df29d0b19aad62e2206286c196addbc12125bb7cda1df2643L8-R10) [[2]](diffhunk://#diff-6215240a5f2a08d30bc9d031b739abdb968869584b36553bce92886f72cd64c0L8-R10) [[3]](diffhunk://#diff-8127010d589c2b8b02d06c68fc3e48bfc5222570f6750c29af4b3ab298e4620fL8-R10)

### Workflow Configuration

* Set `keep_files: false` in the GitHub Pages deployment step to ensure old files are removed during publish, preventing stale content. (.github/workflows/main.yml)